### PR TITLE
Update Kubernetes resources for atomist user

### DIFF
--- a/.atomist/kubernetes/deployment.json
+++ b/.atomist/kubernetes/deployment.json
@@ -4,6 +4,16 @@
       "spec": {
         "containers": [
           {
+            "env": [
+              {
+                "name": "ATOMIST_CONFIG_PATH",
+                "value": "/opt/atm/client.config.json"
+              },
+              {
+                "name": "TMPDIR",
+                "value": "/tmp"
+              }
+            ],
             "livenessProbe": {
               "httpGet": {
                 "path": "/health"
@@ -20,9 +30,80 @@
             },
             "resources": {
               "limits": {
-                "cpu": "500m"
+                "cpu": "500m",
+                "memory": "384Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "320Mi"
               }
+            },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "privileged": false,
+              "readOnlyRootFilesystem": true
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/opt/atm",
+                "name": "k8s-sdm",
+                "readOnly": true
+              },
+              {
+                "mountPath": "/home/atomist",
+                "name": "home"
+              },
+              {
+                "mountPath": "/tmp",
+                "name": "tmp"
+              }
+            ]
+          }
+        ],
+        "initContainers": [
+          {
+            "args": [
+              "git config --global user.email 'bot@atomist.com' && git config --global user.name 'Atomist Bot'"
+            ],
+            "command": ["/bin/sh", "-c"],
+            "image": "atomist/k8s-sdm:1.1.0",
+            "name": "home",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "privileged": false,
+              "readOnlyRootFilesystem": true
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/home/atomist",
+                "name": "home"
+              }
+            ]
+          }
+        ],
+        "securityContext": {
+          "fsGroup": 2866,
+          "runAsGroup": 2866,
+          "runAsNonRoot": true,
+          "runAsUser": 2866,
+          "supplementalGroups": [],
+          "sysctls": []
+        },
+        "volumes": [
+          {
+            "name": "k8s-sdm",
+            "secret": {
+              "defaultMode": 288,
+              "secretName": "k8s-sdm"
             }
+          },
+          {
+            "emptyDir": {},
+            "name": "home"
+          },
+          {
+            "emptyDir": {},
+            "name": "tmp"
           }
         ]
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,5 @@ RUN npm ci \
     && npm cache clean --force
 
 COPY . ./
+
+USER atomist:atomist

--- a/assets/kubectl/cluster-wide.yaml
+++ b/assets/kubectl/cluster-wide.yaml
@@ -1,30 +1,32 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: sdm
   labels:
-    app.kubernetes.io/name: k8s-sdm
-    app.kubernetes.io/part-of: k8s-sdm
     app.kubernetes.io/managed-by: atomist
+    app.kubernetes.io/name: sdm
+    app.kubernetes.io/part-of: sdm
+  name: sdm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: atomist
+    app.kubernetes.io/name: k8s-sdm
+    app.kubernetes.io/part-of: k8s-sdm
+    atomist.com/workspaceId: T29E48P34
   name: k8s-sdm
   namespace: sdm
-  labels:
-    app.kubernetes.io/name: k8s-sdm
-    app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: k8s-sdm
   labels:
+    app.kubernetes.io/managed-by: atomist
     app.kubernetes.io/name: k8s-sdm
     app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
+    atomist.com/workspaceId: T29E48P34
+  name: k8s-sdm
 rules:
   - apiGroups: [""]
     resources: ["namespaces", "pods", "secrets", "serviceaccounts", "services"]
@@ -42,14 +44,15 @@ rules:
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: k8s-sdm
   labels:
+    app.kubernetes.io/managed-by: atomist
     app.kubernetes.io/name: k8s-sdm
     app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
+    atomist.com/workspaceId: T29E48P34
+  name: k8s-sdm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -62,58 +65,65 @@ subjects:
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: k8s-sdm
-  namespace: sdm
   labels:
+    app.kubernetes.io/managed-by: atomist
     app.kubernetes.io/name: k8s-sdm
     app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
+    atomist.com/workspaceId: T29E48P34
+  name: k8s-sdm
+  namespace: sdm
 spec:
   replicas: 1
-  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app.kubernetes.io/name: k8s-sdm
+      atomist.com/workspaceId: T29E48P34
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
+        app.kubernetes.io/managed-by: atomist
         app.kubernetes.io/name: k8s-sdm
         app.kubernetes.io/part-of: k8s-sdm
-        app.kubernetes.io/managed-by: atomist
         app.kubernetes.io/version: "1"
+        atomist.com/workspaceId: T29E48P34
     spec:
-      serviceAccountName: k8s-sdm
       containers:
-        - name: k8s-sdm
-          image: atomist/k8s-sdm:1.0.5
-          imagePullPolicy: IfNotPresent
-          env:
+        - env:
             - name: ATOMIST_CONFIG_PATH
               value: /opt/atm/client.config.json
+            - name: TMPDIR
+              value: /tmp
+          image: atomist/k8s-sdm:1.1.0
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: k8s-sdm
           ports:
             - name: http
               containerPort: 2866
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-              scheme: HTTP
-            initialDelaySeconds: 20
-            timeoutSeconds: 3
-            periodSeconds: 20
-            successThreshold: 1
-            failureThreshold: 3
           readinessProbe:
+            failureThreshold: 3
             httpGet:
               path: /health
               port: http
               scheme: HTTP
             initialDelaySeconds: 20
-            timeoutSeconds: 3
             periodSeconds: 20
             successThreshold: 1
-            failureThreshold: 3
+            timeoutSeconds: 3
           resources:
             limits:
               cpu: 500m
@@ -121,17 +131,45 @@ spec:
             requests:
               cpu: 100m
               memory: 320Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/atm
               name: k8s-sdm
               readOnly: true
+            - mountPath: /home/atomist
+              name: home
+            - mountPath: /tmp
+              name: tmp
+      initContainers:
+        - args:
+            - git config --global user.email 'bot@atomist.com' && git config --global user.name 'Atomist Bot'
+          command: ["/bin/sh", "-c"]
+          image: atomist/k8s-sdm:1.1.0
+          name: "home"
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /home/atomist
+              name: home
+      securityContext:
+        fsGroup: 2866
+        runAsGroup: 2866
+        runAsNonRoot: true
+        runAsUser: 2866
+        supplementalGroups: []
+        sysctls: []
+      serviceAccountName: k8s-sdm
       volumes:
         - name: k8s-sdm
           secret:
-            defaultMode: 256
+            defaultMode: 288
             secretName: k8s-sdm
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
+        - emptyDir: {}
+          name: home
+        - emptyDir: {}
+          name: tmp

--- a/assets/kubectl/namespace-scoped.yaml
+++ b/assets/kubectl/namespace-scoped.yaml
@@ -1,20 +1,22 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: k8s-sdm
   labels:
+    app.kubernetes.io/managed-by: atomist
     app.kubernetes.io/name: k8s-sdm
     app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
+    atomist.com/workspaceId: T29E48P34
+  name: k8s-sdm
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: k8s-sdm
   labels:
+    app.kubernetes.io/managed-by: atomist
     app.kubernetes.io/name: k8s-sdm
     app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
+    atomist.com/workspaceId: T29E48P34
+  name: k8s-sdm
 rules:
   - apiGroups: [""]
     resources: ["namespaces", "pods", "secrets", "serviceaccounts", "services"]
@@ -32,14 +34,15 @@ rules:
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: k8s-sdm
   labels:
+    app.kubernetes.io/managed-by: atomist
     app.kubernetes.io/name: k8s-sdm
     app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
+    atomist.com/workspaceId: T29E48P34
+  name: k8s-sdm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -51,57 +54,64 @@ subjects:
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: k8s-sdm
   labels:
+    app.kubernetes.io/managed-by: atomist
     app.kubernetes.io/name: k8s-sdm
     app.kubernetes.io/part-of: k8s-sdm
-    app.kubernetes.io/managed-by: atomist
+    atomist.com/workspaceId: T29E48P34
+  name: k8s-sdm
 spec:
   replicas: 1
-  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app.kubernetes.io/name: k8s-sdm
+      atomist.com/workspaceId: T29E48P34
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
+        app.kubernetes.io/managed-by: atomist
         app.kubernetes.io/name: k8s-sdm
         app.kubernetes.io/part-of: k8s-sdm
-        app.kubernetes.io/managed-by: atomist
         app.kubernetes.io/version: "1"
+        atomist.com/workspaceId: T29E48P34
     spec:
-      serviceAccountName: k8s-sdm
       containers:
-        - name: k8s-sdm
-          image: atomist/k8s-sdm:1.0.5
-          imagePullPolicy: IfNotPresent
-          env:
+        - env:
             - name: ATOMIST_CONFIG_PATH
               value: /opt/atm/client.config.json
+            - name: TMPDIR
+              value: /tmp
+          image: atomist/k8s-sdm:1.1.0
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: k8s-sdm
           ports:
             - name: http
               containerPort: 2866
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-              scheme: HTTP
-            initialDelaySeconds: 20
-            timeoutSeconds: 3
-            periodSeconds: 20
-            successThreshold: 1
-            failureThreshold: 3
           readinessProbe:
+            failureThreshold: 3
             httpGet:
               path: /health
               port: http
               scheme: HTTP
             initialDelaySeconds: 20
-            timeoutSeconds: 3
             periodSeconds: 20
             successThreshold: 1
-            failureThreshold: 3
+            timeoutSeconds: 3
           resources:
             limits:
               cpu: 500m
@@ -109,17 +119,45 @@ spec:
             requests:
               cpu: 100m
               memory: 320Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/atm
               name: k8s-sdm
               readOnly: true
+            - mountPath: /home/atomist
+              name: home
+            - mountPath: /tmp
+              name: tmp
+      initContainers:
+        - args:
+            - git config --global user.email 'bot@atomist.com' && git config --global user.name 'Atomist Bot'
+          command: ["/bin/sh", "-c"]
+          image: atomist/k8s-sdm:1.1.0
+          name: "home"
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /home/atomist
+              name: home
+      securityContext:
+        fsGroup: 2866
+        runAsGroup: 2866
+        runAsNonRoot: true
+        runAsUser: 2866
+        supplementalGroups: []
+        sysctls: []
+      serviceAccountName: k8s-sdm
       volumes:
         - name: k8s-sdm
           secret:
-            defaultMode: 256
+            defaultMode: 288
             secretName: k8s-sdm
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
+        - emptyDir: {}
+          name: home
+        - emptyDir: {}
+          name: tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/k8s-sdm",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/k8s-sdm",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Atomist SDM for deploying, updating, and removing Kubernetes applications",
   "author": {
     "name": "Atomist",


### PR DESCRIPTION
Sort and update cluster-wide and namespace-scoped resource
specifications to work when running as non-root user.

Update deployment spec patch to include everything missing from
default spec and the changes required for non-root use.