### PR TITLE
Apply target for @atomist/sdm-pack-build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -698,9 +698,9 @@
       }
     },
     "@atomist/sdm-pack-build": {
-      "version": "1.0.6-master.20190903202948",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-build/-/sdm-pack-build-1.0.6-master.20190903202948.tgz",
-      "integrity": "sha512-yQ8wcIR0wxc3WQM9UeNaR+g8q/t2/bRR9YDYyLMs/e0GmaCIX8qAJyD1RwE4R3834qzOM+67cqDTWYdPQVcyAg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-build/-/sdm-pack-build-1.0.6.tgz",
+      "integrity": "sha512-VZ3nSP51HfG/UJUyWxAu0xwwLclzVGfYlelVrIJ9wdvfgEvYTV6lrfIAmrzEAfb/EK99KrVmA4aZo2AkP7Fmsw==",
       "requires": {
         "lodash": "^4.17.13"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@atomist/automation-client-ext-logzio": "^1.0.2",
     "@atomist/sdm": "^1.7.0",
     "@atomist/sdm-core": "^1.7.0",
-    "@atomist/sdm-pack-build": "^1.0.6-master.20190903202948",
+    "@atomist/sdm-pack-build": "^1.0.6",
     "@atomist/sdm-pack-docker": "^1.1.0",
     "@atomist/sdm-pack-k8s": "^1.10.0",
     "@atomist/sdm-pack-node": "^1.0.3",


### PR DESCRIPTION
Apply target `npm-project-deps::atomist::sdm-pack-build`:

**New NPM Package Version Update**
Target version for NPM package *@atomist/sdm-pack-build* is `^1.0.6`.
Project *atomist/k8s-sdm/atomist/t29e48p34/npm-project-deps/master* is currently using version `^1.0.6-master.20190903202948`.

_NPM dependencies_
```@atomist/sdm-pack-build (^1.0.6)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::sdm-pack-build=91eb36d7d420ff62f712a3bde8ddf5e0512bba7509508689e49bcd7ac8fe68d2]</code>
</details>